### PR TITLE
Provide spotify's token and login through CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ $ git clone https://github.com/vjo/discover-weekly-archivist.git
 $ cd discover-weekly-archivist
 ```
 
-You need to set your `user_id` (spotify login) and API `token` in `src/discover_weekly_archivist/core.clj`.
-
 Then to compile:
 ```shell
 $ lein uberjar
@@ -42,9 +40,11 @@ discover-weekly-archivist will create a new Spotify playlist with the content of
 Usage: discover-weekly-archivist [options]
 
 Options:
-  -n, --name NAME  Optional: name of the new playlist.
-  -p, --public     Optional: make the new playlist public.
-  -h, --help       Display help.
+  -t, --token TOKEN  Required: Spotify API token.
+  -l, --login LOGIN  Required: Spotify login.
+  -n, --name NAME    Optional: name of the new playlist.
+  -p, --public       Optional: make the new playlist public.
+  -h, --help         Display help.
 
 ```
 

--- a/src/discover_weekly_archivist/core.clj
+++ b/src/discover_weekly_archivist/core.clj
@@ -3,7 +3,6 @@
             [clojure.string :as string]
             [clj-spotify.core :as sptfy]
             [clj-time.core :as t]
-            [clj-time.periodic :as p]
             [clj-time.format :as f])
   (:gen-class :main true))
 

--- a/src/discover_weekly_archivist/core.clj
+++ b/src/discover_weekly_archivist/core.clj
@@ -1,5 +1,5 @@
 (ns discover-weekly-archivist.core
-  (:require [clojure.tools.cli :refer [parse-opts]]
+  (:require [clojure.tools.cli :as cli]
             [clojure.string :as string]
             [clj-spotify.core :as sptfy]
             [clj-time.core :as t]
@@ -7,15 +7,12 @@
             [clj-time.format :as f])
   (:gen-class :main true))
 
+(def dw-owner-id "spotifydiscover")
+
 (def cli-options
   [["-n" "--name NAME" "Optional: name of the new playlist."]
    ["-p" "--public" "Optional: make the new playlist public." :default false]
    ["-h" "--help" "Display help."]])
-
-(def dw-owner-id "spotifydiscover")
-
-(def token
-  "") ;; Add your token here, see README
 
 (defn usage [options-summary]
   (->> ["discover-weekly-archivist will create a new Spotify playlist with the content of your \"Discover Weekly\" playlist."
@@ -37,25 +34,25 @@
   (println msg)
   (System/exit status))
 
-(defn add-tracks-to-playlist [user_id playlist_id tracks]
+(defn add-tracks-to-playlist [user_id playlist_id tracks token]
   (let [{:keys [error snapshot_id]} (sptfy/add-tracks-to-a-playlist {:user_id user_id :playlist_id playlist_id :uris tracks} token)]
     (cond
       error (exit 1 (error-sptfy error)))
     snapshot_id))
 
-(defn create-playlist [user_id name public]
+(defn create-playlist [user_id name public token]
   (let [{:keys [error id]} (sptfy/create-a-playlist {:user_id user_id :name name :public public} token)]
     (cond
       error (exit 1 (error-sptfy error)))
     id)) ; return the new playlist id
 
-(defn get-discover-weekly-playlist-id [user_id]
+(defn get-discover-weekly-playlist-id [user_id token]
   (let [{:keys [error items]} (sptfy/get-a-list-of-a-users-playlists {:user_id user_id :limit 50 :offset 0} token)]
     (cond
       error (exit 1 (error-sptfy error)))
     (:id (first (filter #(= "Discover Weekly" (:name %)) items))))) ;; return the "Discover Weekly" playlist id
 
-(defn get-playlist-tracks [playlist_id owner_id]
+(defn get-playlist-tracks [playlist_id owner_id token]
   (let [{:keys [error items]} (sptfy/get-a-playlists-tracks {:playlist_id playlist_id :owner_id owner_id :fields "items(track.uri)" :limit 50 :offset 0} token)]
     (cond
       error (exit 1 (error-sptfy error)))
@@ -70,16 +67,16 @@
 (defn create-playlist-name []
   (str (#(f/unparse (f/formatters :year-month-day) %) (find-current-monday)) " Discover Weekly")) ; return something like "2016-03-21 Discover Weekly"
 
-(defn do-transfer [name, user-id, public]
+(defn do-transfer [user-id, token, name, public]
   (let [playlist-name (if (not (nil? name)) name (create-playlist-name))
-        dw_playlist_id (get-discover-weekly-playlist-id user-id)
-        dw_tracks (get-playlist-tracks dw_playlist_id dw-owner-id)
-        new_playlist_id (create-playlist user-id playlist-name public)
-        snapshot_id (add-tracks-to-playlist user-id new_playlist_id dw_tracks)]
+        dw_playlist_id (get-discover-weekly-playlist-id user-id token)
+        dw_tracks (get-playlist-tracks dw_playlist_id dw-owner-id token)
+        new_playlist_id (create-playlist user-id playlist-name public token)
+        snapshot_id (add-tracks-to-playlist user-id new_playlist_id dw_tracks token)]
     (println "Success, snapshot_id:" snapshot_id)))
 
 (defn -main [& args]
-  (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
+  (let [{:keys [options arguments errors summary]} (cli/parse-opts args cli-options)]
     ;; Handle help and error conditions
     (cond
       (:help options) (exit 0 (usage summary))
@@ -87,6 +84,7 @@
     ;; Execute program with options
 
     (do-transfer
-      (:name options)
       "" ; Add your login here, see README
+      "" ; Add your token here, see README
+      (:name options)
       (:public options))))

--- a/src/discover_weekly_archivist/core.clj
+++ b/src/discover_weekly_archivist/core.clj
@@ -9,7 +9,9 @@
 (def dw-owner-id "spotifydiscover")
 
 (def cli-options
-  [["-n" "--name NAME" "Optional: name of the new playlist."]
+  [["-t" "--token TOKEN" "Required: Spotify API token."]
+   ["-l" "--login LOGIN" "Required: Spotify login."]
+   ["-n" "--name NAME" "Optional: name of the new playlist."]
    ["-p" "--public" "Optional: make the new playlist public." :default false]
    ["-h" "--help" "Display help."]])
 
@@ -80,10 +82,19 @@
     (cond
       (:help options) (exit 0 (usage summary))
       errors (exit 1 (error-msg errors)))
+
+    ; todo: right way to do the same?
+    (cond
+      (nil? (:token options))
+      (exit 1 (error-msg ["Token argument is required."])))
+    (cond
+      (nil? (:login options))
+      (exit 1 (error-msg ["Login argument is required."])))
+
     ;; Execute program with options
 
     (do-transfer
-      "" ; Add your login here, see README
-      "" ; Add your token here, see README
+      (:login options)
+      (:token options)
       (:name options)
       (:public options))))

--- a/src/discover_weekly_archivist/core.clj
+++ b/src/discover_weekly_archivist/core.clj
@@ -12,6 +12,8 @@
    ["-p" "--public" "Optional: make the new playlist public." :default false]
    ["-h" "--help" "Display help."]])
 
+(def dw-owner-id "spotifydiscover")
+
 (def token
   "") ;; Add your token here, see README
 
@@ -68,6 +70,14 @@
 (defn create-playlist-name []
   (str (#(f/unparse (f/formatters :year-month-day) %) (find-current-monday)) " Discover Weekly")) ; return something like "2016-03-21 Discover Weekly"
 
+(defn do-transfer [name, user-id, public]
+  (let [playlist-name (if (not (nil? name)) name (create-playlist-name))
+        dw_playlist_id (get-discover-weekly-playlist-id user-id)
+        dw_tracks (get-playlist-tracks dw_playlist_id dw-owner-id)
+        new_playlist_id (create-playlist user-id playlist-name public)
+        snapshot_id (add-tracks-to-playlist user-id new_playlist_id dw_tracks)]
+    (println "Success, snapshot_id:" snapshot_id)))
+
 (defn -main [& args]
   (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
     ;; Handle help and error conditions
@@ -76,12 +86,7 @@
       errors (exit 1 (error-msg errors)))
     ;; Execute program with options
 
-    (def user_id "") ; Add your login here, see README
-    (def dw_owner_id "spotifydiscover")
-
-    (let [playlist-name (if (string? (:name options)) (:name options) (create-playlist-name))
-          dw_playlist_id (get-discover-weekly-playlist-id user_id)
-          dw_tracks (get-playlist-tracks dw_playlist_id dw_owner_id)
-          new_playlist_id (create-playlist user_id playlist-name (:public options))
-          snapshot_id (add-tracks-to-playlist user_id new_playlist_id dw_tracks)]
-      (println "Success, snapshot_id:" snapshot_id))))
+    (do-transfer
+      (:name options)
+      "" ; Add your login here, see README
+      (:public options))))


### PR DESCRIPTION
This PR contains next changes:
- pass login and token explicitly as function arguments where applicable
- extract main logic in separate function `do-transfer`
- add token and login options
